### PR TITLE
fix: resolve lint warnings across project

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -21,13 +21,14 @@ Example:
 import asyncio
 import argparse
 import re
-from typing import Dict, List, Any, Optional
-from urllib.parse import urlparse, urljoin
+from datetime import datetime
+from typing import Any, Dict
+from urllib.parse import urljoin, urlparse
+
+from langchain_aws import ChatBedrockConverse
+from langchain_core.tools import tool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.prebuilt import create_react_agent
-from langchain_aws import ChatBedrock, ChatBedrockConverse
-from langchain_core.tools import tool
-import mcp
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 
@@ -126,8 +127,8 @@ async def invoke_mcp_tool(mcp_registry_url: str, server_name: str, tool_name: st
     
     try:
         # Create an MCP SSE client and call the tool
-        async with mcp.client.sse.sse_client(server_url) as (read, write):
-            async with mcp.ClientSession(read, write, sampling_callback=None) as session:
+        async with sse_client(server_url) as (read, write):
+            async with ClientSession(read, write, sampling_callback=None) as session:
                 # Initialize the connection
                 await session.initialize()
                 
@@ -143,7 +144,6 @@ async def invoke_mcp_tool(mcp_registry_url: str, server_name: str, tool_name: st
     except Exception as e:
         return f"Error invoking MCP tool: {str(e)}"
 
-from datetime import datetime
 current_utc_time = str(datetime.utcnow())
 SYSTEM_PROMPT = f"""
 <instructions>
@@ -271,7 +271,7 @@ def print_agent_response(response_dict: Dict[str, Any]) -> None:
         
         # Print any tool calls
         if tool_calls:
-            print(f"\nTOOL CALLS:")
+            print("\nTOOL CALLS:")
             for tc in tool_calls:
                 print(f"  {tc}")
         print(f"{'=' * 20} END OF {msg_type} MESSAGE #{i} {'=' * 20}{reset}")

--- a/registry/oauth_service.py
+++ b/registry/oauth_service.py
@@ -1,4 +1,3 @@
-import asyncio
 import secrets
 import hashlib
 import base64
@@ -6,7 +5,7 @@ import httpx
 import json
 from datetime import datetime, timedelta
 from typing import Dict, Any, Optional, List
-from urllib.parse import urlencode, parse_qs, urlparse, urljoin
+from urllib.parse import urlencode, urljoin
 from dataclasses import dataclass, asdict
 import logging
 
@@ -75,7 +74,6 @@ class OAuthDiscovery:
         
         # Normalize base URL
         base_url = base_url.rstrip('/')
-        parsed_url = urlparse(base_url)
         
         discovered_endpoints = {}
         
@@ -184,7 +182,7 @@ class OAuthDiscovery:
                                 discovered_endpoints['authorization_url'] = auth_url
                                 logger.info(f"Found OAuth endpoints via pattern matching: token={token_url}, auth={auth_url}")
                                 return discovered_endpoints
-                    except:
+                    except Exception:
                         # OPTIONS failed, try HEAD
                         response = await client.head(token_url)
                         if response.status_code in [200, 405]:  # 405 is OK - means endpoint exists but doesn't support HEAD
@@ -297,7 +295,7 @@ class OAuthManager:
         
         config = self._configs[server_path]
         if config.grant_type != "authorization_code":
-            raise ValueError(f"Authorization URL only applicable for authorization_code flow")
+            raise ValueError("Authorization URL only applicable for authorization_code flow")
         
         # Generate state and PKCE parameters
         state = secrets.token_urlsafe(32)
@@ -702,7 +700,7 @@ class OAuthManager:
                             registration_endpoint = potential_endpoint
                             logger.info(f"Found potential registration endpoint: {registration_endpoint}")
                             break
-                except:
+                except Exception:
                     continue
         
         if not registration_endpoint:

--- a/servers/currenttime/server.py
+++ b/servers/currenttime/server.py
@@ -3,14 +3,14 @@ This server provides an interface to get the current time in a specified timezon
 """
 
 import os
-import time
-import random
-import requests
 import argparse
 import logging
-from mcp.server.fastmcp import FastMCP
-from pydantic import BaseModel, Field
+from datetime import datetime
 from typing import Annotated
+
+import pytz
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 # Configure logging
 logging.basicConfig(
@@ -73,10 +73,6 @@ The user's location is: {location}
 """
     return system_prompt
 
-
-
-from datetime import datetime
-import pytz
 
 def get_current_time_in_timezone(timezone_name):
     """

--- a/servers/fininfo/server.py
+++ b/servers/fininfo/server.py
@@ -9,8 +9,7 @@ import argparse
 import logging
 from pydantic import BaseModel, Field
 from mcp.server.fastmcp import FastMCP
-from typing import Dict, Any, Optional, ClassVar, Annotated
-from pydantic import validator
+from typing import Annotated, Any, ClassVar, Dict, Optional
 from dotenv import load_dotenv
 
 # Configure logging

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel, Field
 from mcp.server.fastmcp import FastMCP
 from typing import Dict, Any, Optional, ClassVar, List
 from dotenv import load_dotenv
-import os
 from sentence_transformers import SentenceTransformer # Added
 import numpy as np # Added
 from sklearn.metrics.pairwise import cosine_similarity # Added
@@ -124,7 +123,6 @@ async def load_faiss_data_for_mcpgw():
             _last_faiss_index_mtime = None
 
         # Check FAISS metadata file
-        metadata_file_changed = False
         if FAISS_METADATA_PATH_MCPGW.exists():
             try:
                 current_metadata_mtime = await asyncio.to_thread(os.path.getmtime, FAISS_METADATA_PATH_MCPGW)
@@ -134,7 +132,6 @@ async def load_faiss_data_for_mcpgw():
                         content = await asyncio.to_thread(f.read)
                         _faiss_metadata_mcpgw = await asyncio.to_thread(json.loads, content)
                     _last_faiss_metadata_mtime = current_metadata_mtime
-                    metadata_file_changed = True
                     logger.info(f"MCPGW: FAISS metadata loaded. Paths: {len(_faiss_metadata_mcpgw.get('metadata', {})) if _faiss_metadata_mcpgw else 'N/A'}")
                 else:
                     logger.debug("MCPGW: FAISS metadata file unchanged since last load.")
@@ -604,7 +601,7 @@ async def healthcheck() -> Dict[str, Any]:
     """
     try:
         # Connect to the WebSocket endpoint
-        registry_ws_url = f"ws://localhost:7860/ws/health_status"
+        registry_ws_url = "ws://localhost:7860/ws/health_status"
         logger.info(f"Connecting to WebSocket endpoint: {registry_ws_url}")
         
         async with websockets.connect(registry_ws_url) as websocket:

--- a/servers/realserverfaketools/client.py
+++ b/servers/realserverfaketools/client.py
@@ -12,7 +12,6 @@ Example:
 
 import argparse
 import logging
-import json
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 

--- a/servers/realserverfaketools/server.py
+++ b/servers/realserverfaketools/server.py
@@ -9,10 +9,10 @@ import secrets  # Replaced random with secrets
 import argparse
 import logging
 import json
-from datetime import datetime, timedelta
+from datetime import datetime
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field
-from typing import Annotated, List, Dict, Optional, Union, Any
+from typing import Annotated, Any, Dict, List, Optional
 
 # Configure logging
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- tidy agent imports and remove stray f-strings
- resolve registry lint warnings and stray f-strings
- clean server modules by removing unused imports and unused vars

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c19dd31b74832fbda98490670290e4