### PR TITLE
Add comprehensive emoji reference for developers

### DIFF
--- a/docs/emoji-for-developers.md
+++ b/docs/emoji-for-developers.md
@@ -1,0 +1,367 @@
+# Emoji for Developers
+
+Developers rely on quick visual cues to highlight intent, status, and urgency across commit messages, pull requests, issue trackers, docs, chat, and release notes. This reference curates a comprehensive, modern collection of emoji grouped by use-case so you can communicate faster without sacrificing clarity. Every entry includes the common shortcode (compatible with GitHub, Slack, Discord, and many Markdown renderers), along with guidance on when to use it.
+
+---
+
+## Using Emoji Effectively
+
+| Context | Tips |
+| --- | --- |
+| **Commit messages** | Keep emoji at the beginning (e.g., `:sparkles: Add autocomplete to search`). Limit to one or two so the subject remains readable. |
+| **Pull requests & issues** | Use emoji to highlight key sections (`:warning:` before a breaking change) or summarize status in titles (`:white_check_mark:` merged, `:construction:` WIP). |
+| **Docs & READMEs** | Integrate emoji into headings for scannability (`## :toolbox: Tooling`). Combine with tables for quick reference. |
+| **Chat & stand-ups** | Standardize daily stand-up cues (`:rocket:` shipped, `:beetle:` blocked). Pair with text to avoid ambiguity. |
+| **Dashboards** | Map emoji to severity or lifecycle statuses when color isn’t available (e.g., `:red_circle:` Critical, `:yellow_circle:` Warning). |
+
+> **Tip:** Emojis render differently across platforms. Favor universal glyphs over niche ones when communicating cross-platform.
+
+---
+
+## Quick Start Cheat Sheet
+
+| Emoji | Shortcode | Use Case |
+| --- | --- | --- |
+| 🚧 | `:construction:` | Work in progress / draft PRs |
+| ✅ | `:white_check_mark:` | Task complete / tests passing |
+| 🐞 | `:bug:` | Bug report or reproduction steps |
+| ⚠️ | `:warning:` | Breaking change or caution |
+| ✨ | `:sparkles:` | New feature or enhancement |
+| ♻️ | `:recycle:` | Refactor or cleanup |
+| 🧪 | `:test_tube:` | Testing, QA, experimentation |
+| 🔐 | `:lock:` | Security fix or compliance update |
+| 🆕 | `:new:` | Recently added component or API |
+| 🚀 | `:rocket:` | Release, deployment, or launch announcement |
+
+---
+
+## Workflow & Project Status
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🧭 | `:compass:` | Roadmap discussion or direction-setting issue |
+| 🗺️ | `:world_map:` | Architectural overview or topology diagram references |
+| 📝 | `:memo:` | Meeting notes, documentation tasks |
+| 🏁 | `:checkered_flag:` | Milestone reached / sprint complete |
+| ⏳ | `:hourglass_flowing_sand:` | Pending action, waiting on dependency |
+| 🚦 | `:vertical_traffic_light:` | Stage gate or go/no-go checkpoints |
+| 🔄 | `:arrows_clockwise:` | Iteration in progress / feedback loop |
+| 🏗️ | `:building_construction:` | Large-scale initiative / infrastructure work |
+| 🧱 | `:bricks:` | Foundation work / base layer updates |
+| 🧵 | `:thread:` | Threaded discussion or follow-up comments |
+
+---
+
+## Code, Repositories & Version Control
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 📦 | `:package:` | New release, published package |
+| 🧰 | `:toolbox:` | Tooling, developer utilities |
+| 📁 | `:file_folder:` | File or directory level changes |
+| 🗃️ | `:card_file_box:` | Data migrations / schema storage |
+| 🗂️ | `:card_index_dividers:` | Organizing modules or repository structure |
+| 🧱 | `:brick:` | Dependency pinning / base image updates |
+| 🪵 | `:wood:` | Feature flags or toggles (logs) |
+| 🧾 | `:receipt:` | Changelog / release notes updates |
+| 🪝 | `:hook:` | Git hooks or automation scripts |
+| 🧷 | `:safety_pin:` | Hotfix to keep things stable |
+| 🔖 | `:bookmark:` | Tagged release or version bump |
+| 🧱 | `:bricks:` | Monorepo workspace organization |
+| 🧩 | `:jigsaw:` | Module integration or plugin support |
+
+---
+
+## Feature Development & UX
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| ✨ | `:sparkles:` | Feature introduction / enhancements |
+| 🪄 | `:magic_wand:` | Developer experience improvements, automation |
+| 🎛️ | `:control_knobs:` | Configuration options, settings pages |
+| 🧭 | `:compass:` | Navigation updates |
+| 🧑‍💻 | `:technologist:` | Developer-focused tutorials or guides |
+| 🎨 | `:art:` | UI polish, styling, theming |
+| 🧴 | `:lotion_bottle:` | UX improvements, ergonomics |
+| 🪟 | `:window:` | Front-end layout components |
+| 🪞 | `:mirror:` | Responsive layout or preview fixes |
+| 📱 | `:iphone:` | Mobile experience updates |
+| 🧪 | `:test_tube:` | Experiments / A/B tests |
+| 🧱 | `:brick:` | Component or design system foundations |
+
+---
+
+## Quality, Testing & Automation
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| ✅ | `:white_check_mark:` | Passed tests / validated scenarios |
+| ❌ | `:x:` | Failing tests / blockers |
+| 🟨 | `:yellow_square:` | Flaky test identified |
+| 🧪 | `:test_tube:` | Adding or improving test coverage |
+| 🧬 | `:dna:` | Property-based or fuzz testing |
+| 📊 | `:bar_chart:` | Metrics, dashboards, coverage reports |
+| ♻️ | `:recycle:` | Refactors to improve code health |
+| 🧹 | `:broom:` | Cleanup tasks, lint fixes |
+| 🔁 | `:repeat:` | Rerun workflows / retries |
+| 🤖 | `:robot:` | CI/CD automation, bots |
+| 🧯 | `:fire_extinguisher:` | Flaky test mitigation |
+| 🛡️ | `:shield:` | Adding guardrails / validations |
+
+---
+
+## Security & Compliance
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🔐 | `:lock:` | Security improvements, encryption |
+| 🛡️ | `:shield:` | Protective measures, auth hardening |
+| 🕵️‍♀️ | `:female_detective:` | Investigation into security incident |
+| 🕵️‍♂️ | `:male_detective:` | Threat hunting / audit |
+| 🚨 | `:rotating_light:` | Critical security advisory |
+| 🧯 | `:fire_extinguisher:` | Incident response / mitigation |
+| 🧮 | `:abacus:` | Compliance evidence or reporting |
+| 🪪 | `:identification_card:` | Identity & access management |
+| 🪬 | `:hamsa:` | Safety features or guardrails |
+| 🩺 | `:stethoscope:` | Security health check |
+
+---
+
+## Infrastructure, DevOps & Cloud
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| ☁️ | `:cloud:` | Cloud resources, general infra |
+| 🏗️ | `:building_construction:` | Provisioning / Terraform / Pulumi |
+| 🛠️ | `:hammer_and_wrench:` | Maintenance, operations |
+| 🧱 | `:bricks:` | Base images, container hardening |
+| 🐳 | `:whale:` | Docker updates |
+| 🐙 | `:octocat:` | GitHub-specific automation |
+| 🛳️ | `:passenger_ship:` | Kubernetes clusters / workloads |
+| 🔌 | `:electric_plug:` | Integrations, connectors |
+| 🌐 | `:globe_with_meridians:` | DNS, networking, CDN |
+| 🚦 | `:traffic_light:` | Rollouts, canaries, feature gates |
+| 🧭 | `:compass:` | Multi-region routing |
+| 🛰️ | `:satellite:` | Telemetry, monitoring pipelines |
+| 🧱 | `:brick:` | Base image rebuilds |
+| 🧲 | `:magnet:` | Load balancing / sticky sessions |
+
+---
+
+## Data, AI & Analytics
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🧠 | `:brain:` | Machine learning models, AI features |
+| 🤖 | `:robot:` | Automation scripts, AI agents |
+| 📈 | `:chart_with_upwards_trend:` | KPI improvements, growth metrics |
+| 📉 | `:chart_with_downwards_trend:` | Regressions, incident impact |
+| 🗃️ | `:card_file_box:` | Dataset updates, warehouse changes |
+| 🧮 | `:abacus:` | Analytics instrumentation |
+| 🧬 | `:dna:` | Generative AI fine-tuning, embeddings |
+| 🛰️ | `:satellite:` | Data pipelines, observability |
+| 🪙 | `:coin:` | Cost analysis, FinOps |
+| 🧲 | `:magnet:` | Recommendation engines / personalization |
+| 🗜️ | `:clamp:` | Compression, optimization |
+
+---
+
+## Collaboration & Communication
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🙌 | `:raised_hands:` | Celebrations, gratitude |
+| 👏 | `:clap:` | Kudos for contributions |
+| 🤝 | `:handshake:` | Partnership, cross-team work |
+| 🙇 | `:bow:` | Acknowledging help, appreciation |
+| 🗣️ | `:speaking_head:` | Announcement or broadcast |
+| 📣 | `:mega:` | Important updates, release notes |
+| 📨 | `:incoming_envelope:` | Notifications, follow-ups |
+| 📅 | `:date:` | Scheduling reminders |
+| 🧑‍🤝‍🧑 | `:people_holding_hands:` | Community initiatives |
+| 🎉 | `:tada:` | Celebrations, milestone achievements |
+| 💬 | `:speech_balloon:` | Discussion threads |
+
+---
+
+## Incident Response & Health
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🔥 | `:fire:` | Major incident, outage |
+| 🧯 | `:fire_extinguisher:` | Mitigation in progress |
+| 🚒 | `:fire_engine:` | Incident commander updates |
+| 🚑 | `:ambulance:` | Urgent bug fix / hotfix |
+| 🚨 | `:rotating_light:` | Critical alert |
+| 🛎️ | `:bellhop_bell:` | On-call handoff |
+| 🩺 | `:stethoscope:` | Health checks, monitoring |
+| 🧰 | `:toolbox:` | Runbook or tooling references |
+| 🧊 | `:ice_cube:` | Incident resolved / cooled down |
+| 🧵 | `:thread:` | Post-incident follow-up thread |
+| 📟 | `:pager:` | Pager alerts |
+
+---
+
+## Documentation & Knowledge Sharing
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 📚 | `:books:` | Knowledge base updates |
+| 📖 | `:book:` | Detailed guides |
+| 🧾 | `:scroll:` | Policies, standards |
+| 🪧 | `:placard:` | Announcing new docs |
+| 🧮 | `:abacus:` | Architecture decision records |
+| 🧭 | `:compass:` | Information architecture mapping |
+| 🗂️ | `:card_index_dividers:` | Organizing doc sections |
+| 🖊️ | `:pen:` | Editing / copy updates |
+| 🔍 | `:mag:` | Research or discovery |
+| 🧠 | `:brain:` | Knowledge sharing session |
+
+---
+
+## Accessibility & Inclusive Design
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| ♿ | `:wheelchair:` | Accessibility feature or audit |
+| 🦻 | `:ear_with_hearing_aid:` | Audio accessibility |
+| 🦯 | `:white_cane:` | Navigation improvements |
+| 👁️ | `:eye:` | Visual improvements |
+| 🧏‍♀️ | `:deaf_woman:` | Inclusive communication updates |
+| 🧏‍♂️ | `:deaf_man:` | Sign language support |
+| ♾️ | `:infinity:` | Inclusivity / neurodiversity initiatives |
+
+---
+
+## Productivity & Task Management
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| ✅ | `:white_check_mark:` | Completed tasks |
+| 🟡 | `:yellow_circle:` | In progress |
+| 🔴 | `:red_circle:` | Blocked |
+| 🟢 | `:green_circle:` | Ready to start |
+| 🗓️ | `:spiral_calendar:` | Sprint planning |
+| 🗂️ | `:card_index_dividers:` | Task organization |
+| ⏰ | `:alarm_clock:` | Deadlines |
+| 🧮 | `:abacus:` | Estimation & sizing |
+| 📌 | `:pushpin:` | Important reminders |
+| 🧾 | `:receipt:` | Retro action items |
+
+---
+
+## Hardware, IoT & Embedded
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🛠️ | `:hammer_and_wrench:` | Hardware assembly / setup |
+| 🪛 | `:screwdriver:` | Firmware tweaks |
+| 🔋 | `:battery:` | Power management |
+| 📡 | `:satellite_antenna:` | Connectivity updates |
+| 🧲 | `:magnet:` | Sensor calibration |
+| 🔧 | `:wrench:` | Mechanical fixes |
+| 🧱 | `:bricks:` | PCB revisions |
+| 🛰️ | `:satellite:` | Remote device monitoring |
+
+---
+
+## Finance, Billing & Commercial
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 💸 | `:money_with_wings:` | Cost spikes, billing anomalies |
+| 💰 | `:moneybag:` | Revenue-related features |
+| 🧾 | `:receipt:` | Invoices, statements |
+| 🧮 | `:abacus:` | Pricing calculations |
+| 🪙 | `:coin:` | Payments, credits |
+| 🏦 | `:bank:` | Financial systems integrations |
+
+---
+
+## Environment & Sustainability
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🌱 | `:seedling:` | Green initiatives, sustainability |
+| 🌿 | `:herb:` | Energy efficiency |
+| 🌍 | `:earth_africa:` | Environmental impact reports |
+| 🔋 | `:battery:` | Power consumption metrics |
+| ♻️ | `:recycle:` | Resource reuse, optimization |
+
+---
+
+## Fun & Morale (Use Sparingly)
+
+| Emoji | Shortcode | Suggested Usage |
+| --- | --- | --- |
+| 🦄 | `:unicorn:` | Ambitious ideas |
+| 🍕 | `:pizza:` | Team lunch, social events |
+| ☕ | `:coffee:` | Break reminders |
+| 🎯 | `:dart:` | Hit goal or KPI |
+| 🧊 | `:ice_cube:` | Chill / non-urgent |
+| 🐙 | `:octopus:` | Tentative / multi-tasking |
+
+---
+
+## Platform & Ecosystem Specific Sets
+
+| Platform | Emoji & Shortcode | Usage |
+| --- | --- | --- |
+| **GitHub Actions** | ⚙️ `:gear:`, 🚀 `:rocket:` | Workflow automation, deployments |
+| **Jira / Issue Trackers** | 🎯 `:dart:`, 📉 `:chart_with_downwards_trend:` | Sprint goals, regression tracking |
+| **Slack** | 🙌 `:raised_hands:`, 🧵 `:thread:` | Reaction norms, threaded updates |
+| **Discord** | 🤖 `:robot:`, 💡 `:bulb:` | Bot updates, idea channels |
+| **Linear / Height** | 🏷️ `:label:`, 🪟 `:window:` | Label changes, UI tasks |
+
+---
+
+## Suggested Workflow Labels
+
+Use emoji to standardize board columns, commit prefixes, or Slack stand-up headers:
+
+| Stage | Emoji | Shortcode |
+| --- | --- | --- |
+| Backlog | 📋 | `:clipboard:` |
+| Ready | 🟢 | `:green_circle:` |
+| In Progress | 🛠️ | `:hammer_and_wrench:` |
+| In Review | 👀 | `:eyes:` |
+| Blocked | ⛔ | `:no_entry:` |
+| Testing | 🧪 | `:test_tube:` |
+| Ready to Launch | 🚀 | `:rocket:` |
+| Done | ✅ | `:white_check_mark:` |
+
+---
+
+## Changelog & Release Note Patterns
+
+| Pattern | Example |
+| --- | --- |
+| **Features** | `✨ Added AI-assisted command palette` |
+| **Fixes** | `🐞 Fixed crash when saving workflows` |
+| **Performance** | `⚡ Improved cold-start time by 45%` |
+| **Security** | `🔐 Patched JWT expiration bug` |
+| **Docs** | `📝 Updated onboarding tutorial with screenshots` |
+| **Tooling** | `🧰 Added Prettier formatting script` |
+| **Dependencies** | `📦 Bumped React to v19` |
+| **Breaking Changes** | `⚠️ Dropped support for Node 16` |
+
+---
+
+## Extending the Set
+
+1. **Adopt Unicode 15+ emoji:** New releases add industry-relevant glyphs (e.g., 🪫 `:low_battery:` for resource depletion, 🪿 `:goose:` for playful alerts). Check [Emojipedia](https://emojipedia.org) for the latest shortcodes.
+2. **Create custom aliases:** GitHub supports `.gemoji` and Slack supports custom emoji uploads—map them to internal tooling (e.g., `:pagerduty:` icon, product logos).
+3. **Automate formatting:** Integrate lint rules (Danger, probot) to enforce emoji prefixes in changelogs or PR titles.
+4. **Document norms:** Share this page in `CONTRIBUTING.md` so contributors understand the communication style.
+
+---
+
+## Further Resources
+
+- [GitHub Emoji Cheat Sheet](https://github.com/ikatyang/emoji-cheat-sheet)
+- [Slack Emoji Guidelines](https://slack.com/help/articles/202931348-Use-emoji-in-Slack)
+- [Unicode Technical Standard #51](https://unicode.org/reports/tr51/)
+- [Emojipedia Release Notes](https://blog.emojipedia.org/)
+
+Stay consistent and intentional—emoji should amplify clarity, not replace context. Standardizing a set of developer-focused icons reduces friction, speeds up async collaboration, and keeps your project fun.
+


### PR DESCRIPTION
## Summary
- add a new docs/emoji-for-developers.md page that restructures the emoji for developers wiki into focused categories
- document usage guidance, workflow labels, changelog patterns, and additional resources for maintaining emoji standards

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d1ab777b50832fa2c1fc1cd8274265)